### PR TITLE
Fix trace log message

### DIFF
--- a/june/native/gles/gles_context.cpp
+++ b/june/native/gles/gles_context.cpp
@@ -134,7 +134,7 @@ void GLESContext::exportFence(JuneFenceExportDescriptor const* descriptor)
                 return;
             }
 
-            spdlog::trace("{} GLES 1Duplicated sync FD: {}", getName(), syncFD);
+            spdlog::trace("{} GLES Duplicated sync FD: {}", getName(), syncFD);
 
             auto syncFDExportDescriptor = reinterpret_cast<JuneFenceSyncFDExportDescriptor*>(current);
             syncFDExportDescriptor->syncFD = syncFD;


### PR DESCRIPTION
## Summary
- fix a typo in GLES context trace logging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684087ed6ca8832e9310fb260de5d9b2