### PR TITLE
Fix Vendor ID log typo

### DIFF
--- a/june/native/vulkan/vulkan_context.cpp
+++ b/june/native/vulkan/vulkan_context.cpp
@@ -298,7 +298,7 @@ void VulkanContext::gatherPhysicalDeviceInfo()
     spdlog::info("Physical Device Id: {}", static_cast<uint32_t>(m_physicalDeviceInfo.physicalDeviceProperties.deviceID));
     spdlog::info("Physical Device Name: {}", m_physicalDeviceInfo.physicalDeviceProperties.deviceName);
     spdlog::info("Physical Device Type: {}", static_cast<uint32_t>(m_physicalDeviceInfo.physicalDeviceProperties.deviceType));
-    spdlog::info("Physical Device Vender ID: {}", static_cast<uint32_t>(m_physicalDeviceInfo.physicalDeviceProperties.vendorID));
+    spdlog::info("Physical Device Vendor ID: {}", static_cast<uint32_t>(m_physicalDeviceInfo.physicalDeviceProperties.vendorID));
 
     vkAPI.GetPhysicalDeviceFeatures(m_vkPhysicalDevice, &m_physicalDeviceInfo.physicalDeviceFeatures);
 


### PR DESCRIPTION
## Summary
- fix spelling of the physical device vendor ID log in Vulkan context

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684088051fb0832ea1900c8fc3dce011