### PR TITLE
Fix NoApi type

### DIFF
--- a/june/native/noapi/noapi_context.cpp
+++ b/june/native/noapi/noapi_context.cpp
@@ -67,7 +67,7 @@ void NoApiContext::exportFence(JuneFenceExportDescriptor const* descriptor)
 
 JuneApiType NoApiContext::getApiType() const
 {
-    return JuneApiType_GLES;
+    return JuneApiType_NoApi;
 }
 
 } // namespace june


### PR DESCRIPTION
## Summary
- fix NoApi context to report the correct API type

## Testing
- `cmake -S . -B build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684087faf930832e944f27314efc95c5